### PR TITLE
disable indentation

### DIFF
--- a/lib/opal/slim.rb
+++ b/lib/opal/slim.rb
@@ -5,8 +5,10 @@ require 'sprockets'
 module Opal
   module Slim
     def self.compiled_slim source
-      engine = ::Slim::Engine.with_options(pretty: false) { ::Slim::Engine.new }
-      engine.call(source).gsub(/(slim_controls\w+) <</, '\1 +=')
+      ::Slim::Engine.with_options(pretty: false) do
+        engine = ::Slim::Engine.new
+        engine.call(source).gsub(/(slim_controls\w+) <</, '\1 +=')
+      end
     end
 
     def self.wrap compiled, file

--- a/lib/opal/slim.rb
+++ b/lib/opal/slim.rb
@@ -5,7 +5,7 @@ require 'sprockets'
 module Opal
   module Slim
     def self.compiled_slim source
-      engine = ::Slim::Engine.new
+      engine = ::Slim::Engine.with_options(pretty: false) { ::Slim::Engine.new }
       engine.call(source).gsub(/(slim_controls\w+) <</, '\1 +=')
     end
 

--- a/spec/opal/slim_spec.rb
+++ b/spec/opal/slim_spec.rb
@@ -8,6 +8,14 @@ describe Opal::Slim do
     expect(compiled).to eq %Q{_buf = []; _buf << (\"<p>lol</p>\".freeze); \n; _buf = _buf.join}
   end
 
+  it 'compiles a plain Slim template without indentation when is enabled' do
+    Slim::Engine.set_options(pretty: true) do
+      template = 'p lol'
+      compiled = ::Opal::Slim.compiled_slim(template)
+      expect(compiled).to eq %Q{_buf = []; _buf << (\"<p>lol</p>\".freeze); \n; _buf = _buf.join}
+    end
+  end
+
   it 'compiles a Slim template with evaluated code' do
     template = '= link_to "hi"'
     compiled = ::Opal::Slim.compiled_slim(template)


### PR DESCRIPTION
The are 2 way to fix #1.
1) Fore to generate slim without indentation
2) Add `indent_dynamic` on browser side

I think we don't need indented html. So we don't need this method also.
